### PR TITLE
Changed fs.watch to fs.watchFile to resolve issues with Vim on OSX

### DIFF
--- a/lib/dircrawler.js
+++ b/lib/dircrawler.js
@@ -182,7 +182,7 @@ DirCrawler.prototype = {
     //console.error('watching file', filepath)
     var self = this
     var w = this.watchers[filepath] = 
-      fs.watch(filepath, function(evt, filename){
+      fs.watchFile(filepath, function(evt, filename){
         self.onFileAccessed(evt, filename, filepath)
       })
     w.on('error', function(){


### PR DESCRIPTION
Changing fs.watch to fs.watchFile resolves an issue with file change detection when using Vim on OS X. 

For more information see this post:
http://www.actionshrimp.com/2012/06/jasmine-node-autotest-with-vim-on-osx/

fixes airportyh/testem#299
