### PR TITLE
Use hasOwnProperty to check if filename in entries

### DIFF
--- a/lib/dir.js
+++ b/lib/dir.js
@@ -25,7 +25,7 @@ Dir.prototype = {
     if (!this.watcher){
       try{
         this.watcher = fs.watch(this.path, function(evt, filename){
-          if (evt === 'change' && filename in self.entries){
+          if (evt === 'change' && self.entries.hasOwnProperty(filename)){
             self.entries[filename].update()
           }else{
             self.update()


### PR DESCRIPTION
This works around an obscure issue when a file or directory in the filesystem happens to share its name with a native javascript function. For example, if a directory called `hasOwnProperty` were to change then `filename in self.entries` would evaluate as `true` even though it’s not _really_ in entries.
