### PR TITLE
Fix `main` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fireworm",
   "version": "0.7.1",
   "description": "A crawling file watcher.",
-  "main": "fireworm.js",
+  "main": "index.js",
   "scripts": {
     "test": "mocha -u tdd tests/*_tests.js"
   },


### PR DESCRIPTION
Fixes a deprecation error:

```
❯ node
Welcome to Node.js v16.13.0.
Type ".help" for more information.
> require('fireworm')
[Function: Fireworm]
> (node:98772) [DEP0128] DeprecationWarning: Invalid 'main' field in '/[…]/node_modules/fireworm/package.json' of 'fireworm.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```